### PR TITLE
Output notes in the same structure as Notes.app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 ### Work data ###
 /input/*.pl
 /input/*.sqlite
-/output/*.txt
+/output/**/*.txt


### PR DESCRIPTION
Hello! I found this useful because [Notes Exporter](https://apps.apple.com/us/app/exporter/id1099120373?mt=12) kept crashing on me. I needed the output to be a bit more organised so I added some features:

- Give each note file its proper title
- Touch each note with its creation timestamp
- File notes under the folders they appear under in the app

Before:

```
output
├── 224.txt
├── 225.txt
├── 226.txt
├── 227.txt
├── 228.txt
...
```

After:

```
output
├── New\ Folder
│ ├── 1 - Example.txt
├── Notes
│ ├── 2 - A\ bottle\ of\ white\ wine\ and\ an\ Eat\ Natural.txt
│ ├── 3 - A\ gesture.txt
```

I'm not a Groovy or Java developer so sorry if the code does anything weird

